### PR TITLE
Use Id attribute instead of Name attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ SHELL := /bin/bash
 
 default: install
 
-install:
+install: fmt
 	go install .
+
+fmt:
+	go fmt ./...
 
 test:
 	go test -parallel=4 ./...

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ provider "pingdirectory" {
 }
 
 resource "pingdirectory_location" "mylocation" {
-  name = "MyLocation"
+  id = "MyLocation"
   description = "My description"
 }
 

--- a/examples/location-example/main.tf
+++ b/examples/location-example/main.tf
@@ -13,6 +13,6 @@ provider "pingdirectory" {
 }
 
 resource "pingdirectory_location" "drangleic" {
-  name = "Drangleic"
+  id = "Drangleic"
   description = "Seek the king"
 }

--- a/examples/server-instance-example/main.tf
+++ b/examples/server-instance-example/main.tf
@@ -14,6 +14,7 @@ provider "pingdirectory" {
 
 resource "pingdirectory_directory_server_instance" "mine" {
   //NOTE This instance name needs to match the instance name generated for the running instance
+  id = "d1db4a163621"
   server_instance_name = "d1db4a163621"
   jmx_port = 1112
   start_tls_enabled = true

--- a/examples/simple-example/main.tf
+++ b/examples/simple-example/main.tf
@@ -13,7 +13,7 @@ provider "pingdirectory" {
 }
 
 resource "pingdirectory_location" "drangleic" {
-  name = "Drangleic"
+  id = "Drangleic"
   description = "Seek the king"
 }
 
@@ -27,13 +27,13 @@ resource "pingdirectory_global_configuration" "global" {
 }
 
 resource "pingdirectory_blind_trust_manager_provider" "blindtest" {
-  name = "Blind Test"
+  id = "Blind Test"
   enabled = true
   include_jvm_default_issuers = true
 }
 
 resource "pingdirectory_file_based_trust_manager_provider" "filetest" {
-  name = "FileTest"
+  id = "FileTest"
   enabled = true
   trust_store_file = "config/keystore"
   trust_store_type = "pkcs12"
@@ -41,12 +41,12 @@ resource "pingdirectory_file_based_trust_manager_provider" "filetest" {
 }
 
 resource "pingdirectory_jvm_default_trust_manager_provider" "jvmtest" {
-  name = "jvmtest"
+  id = "jvmtest"
   enabled = false
 }
 
 resource "pingdirectory_third_party_trust_manager_provider" "tptest" {
-  name = "tptest"
+  id = "tptest"
   enabled = false
   extension_class = "com.unboundid.directory.sdk.common.api.TrustManagerProvider"
   extension_argument = ["val1=one", "val2=two"]

--- a/internal/acctest/resource/config/location_resource_test.go
+++ b/internal/acctest/resource/config/location_resource_test.go
@@ -63,7 +63,7 @@ func TestAccLocation(t *testing.T) {
 func testAccLocationResource(resourceName, locationName, description string) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_location" "%[1]s" {
-	name = "%[2]s"
+	id = "%[2]s"
 	description = "%[3]s"
 }`, resourceName, locationName, description)
 }
@@ -71,7 +71,7 @@ resource "pingdirectory_location" "%[1]s" {
 func testAccLocationResourceNoDescription(resourceName, locationName string) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_location" "%[1]s" {
-	name = "%[2]s"
+	id = "%[2]s"
 }`, resourceName, locationName)
 }
 

--- a/internal/acctest/resource/config/serverinstance/directory_server_instance_test.go
+++ b/internal/acctest/resource/config/serverinstance/directory_server_instance_test.go
@@ -70,6 +70,7 @@ func TestAccDirectoryServerInstance(t *testing.T) {
 func testAccDirectoryserverInstanceResource(resourceName, instanceName string, resourceModel testModel) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_directory_server_instance" "%[1]s" {
+	id = "%[2]s"
 	server_instance_name = "%[2]s"
 	jmx_port = %[3]d
 	start_tls_enabled = %[4]t

--- a/internal/acctest/resource/config/trustmanagerprovider/trust_manager_provider_test.go
+++ b/internal/acctest/resource/config/trustmanagerprovider/trust_manager_provider_test.go
@@ -131,7 +131,7 @@ func TestAccThirdPartyTrustManagerProvider(t *testing.T) {
 func testAccBlindTrustManagerProviderResource(resourceName, providerName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_blind_trust_manager_provider" "%[1]s" {
-	name = "%[2]s"
+	id = "%[2]s"
 	enabled = %[3]t
 }`, resourceName, providerName, enabled)
 }
@@ -139,7 +139,7 @@ resource "pingdirectory_blind_trust_manager_provider" "%[1]s" {
 func testAccFileBasedTrustManagerProviderResource(resourceName, providerName string, enabled bool, trustStoreFile, trustStoreType string) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_file_based_trust_manager_provider" "%[1]s" {
-	name = "%[2]s"
+	id = "%[2]s"
 	enabled = %[3]t
 	trust_store_file = "%[4]s"
 	trust_store_type = "%[5]s"
@@ -149,7 +149,7 @@ resource "pingdirectory_file_based_trust_manager_provider" "%[1]s" {
 func testAccJvmDefaultTrustManagerProviderResource(resourceName, providerName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_jvm_default_trust_manager_provider" "%[1]s" {
-	name = "%[2]s"
+	id = "%[2]s"
 	enabled = %[3]t
 }`, resourceName, providerName, enabled)
 }
@@ -157,7 +157,7 @@ resource "pingdirectory_jvm_default_trust_manager_provider" "%[1]s" {
 func testAccThirdPartyTrustManagerProviderResource(resourceName, providerName string, enabled bool, extensionClass string, extensionArgument []string) string {
 	return fmt.Sprintf(`
 resource "pingdirectory_third_party_trust_manager_provider" "%[1]s" {
-	name = "%[2]s"
+	id = "%[2]s"
 	enabled = %[3]t
 	extension_class = "%[4]s"
 	extension_argument = %[5]s

--- a/internal/resource/config/common.go
+++ b/internal/resource/config/common.go
@@ -4,6 +4,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	client "github.com/pingidentity/pingdirectory-go-client/v9100"
 )
@@ -25,7 +27,7 @@ func GetRequiredActionsObjectType() types.ObjectType {
 }
 
 // Get schema elements common to all resources
-func AddCommonSchema(s *schema.Schema) {
+func AddCommonSchema(s *schema.Schema, idRequired bool) {
 	s.Attributes["last_updated"] = schema.StringAttribute{
 		Description: "Timestamp of the last Terraform update of this resource.",
 		Computed:    true,
@@ -46,9 +48,21 @@ func AddCommonSchema(s *schema.Schema) {
 		Required:    false,
 		Optional:    false,
 	}
-	s.Attributes["id"] = schema.StringAttribute{
-		Description: "Id attribute required for acceptance testing.",
-		Computed:    true,
+	// If ID is required (for instantiable config objects) then set it as Required and
+	// require replace when changing. Otherwise, mark it as Computed.
+	if idRequired {
+		s.Attributes["id"] = schema.StringAttribute{
+			Description: "Name of this object.",
+			Required:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		}
+	} else {
+		s.Attributes["id"] = schema.StringAttribute{
+			Description: "Placeholder name of this object required by Terraform.",
+			Computed:    true,
+		}
 	}
 }
 

--- a/internal/resource/config/global_configuration_resource.go
+++ b/internal/resource/config/global_configuration_resource.go
@@ -577,7 +577,7 @@ func (r *globalConfigurationResource) Schema(ctx context.Context, req resource.S
 			},
 		},
 	}
-	AddCommonSchema(&schema)
+	AddCommonSchema(&schema, false)
 	resp.Schema = schema
 }
 
@@ -694,7 +694,7 @@ func (r *globalConfigurationResource) Read(ctx context.Context, req resource.Rea
 // Read a GlobalConfigurationRespnse object into the model struct
 func readGlobalConfigurationResponse(ctx context.Context, r *client.GlobalConfigurationResponse, state *globalConfigurationResourceModel) {
 	// Placeholder Id value for acceptance test framework
-	state.Id = types.StringValue(r.InstanceName)
+	state.Id = types.StringValue("id")
 	state.InstanceName = types.StringValue(r.InstanceName)
 	state.Location = internaltypes.StringTypeOrNil(r.Location, true)
 	state.ConfigurationServerGroup = internaltypes.StringTypeOrNil(r.ConfigurationServerGroup, true)

--- a/internal/resource/config/serverinstance/authorize_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/authorize_server_instance_resource.go
@@ -67,7 +67,7 @@ func (r *authorizeServerInstanceResource) Create(ctx context.Context, req resour
 		return
 	}
 
-	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString()).Execute()
+	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -84,7 +84,7 @@ func (r *authorizeServerInstanceResource) Create(ctx context.Context, req resour
 	readAuthorizeServerInstanceResponse(ctx, getResp.AuthorizeServerInstanceResponse, &state)
 
 	// Determine what changes need to be made to match the plan
-	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 	ops := CreateCommonServerInstanceOperations(plan, state)
 
 	if len(ops) > 0 {
@@ -123,8 +123,7 @@ func (r *authorizeServerInstanceResource) Create(ctx context.Context, req resour
 // Read a AuthorizeServerInstanceResponse object into the model struct.
 // Use empty string for nils since everything is marked as computed.
 func readAuthorizeServerInstanceResponse(ctx context.Context, r *client.AuthorizeServerInstanceResponse, state *CommonServerInstanceResourceModel) {
-	// Placeholder Id value for acceptance test framework
-	state.Id = types.StringValue(r.ServerInstanceName)
+	state.Id = internaltypes.StringTypeOrNil(r.Id, true)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
 	state.ClusterName = types.StringValue(r.ClusterName)
 	state.ServerInstanceLocation = internaltypes.StringTypeOrNil(r.ServerInstanceLocation, true)
@@ -162,7 +161,7 @@ func (r *authorizeServerInstanceResource) Read(ctx context.Context, req resource
 		return
 	}
 
-	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.ServerInstanceName.ValueString()).Execute()
+	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -198,7 +197,7 @@ func (r *authorizeServerInstanceResource) Update(ctx context.Context, req resour
 	// Get the current state to see how any attributes are changing
 	var state CommonServerInstanceResourceModel
 	req.State.Get(ctx, &state)
-	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 
 	// Determine what update operations are necessary
 	ops := CreateCommonServerInstanceOperations(plan, state)
@@ -242,6 +241,6 @@ func (r *authorizeServerInstanceResource) Delete(ctx context.Context, req resour
 }
 
 func (r *authorizeServerInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to Name attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/resource/config/serverinstance/directory_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/directory_server_instance_resource.go
@@ -36,7 +36,6 @@ type directoryServerInstanceResource struct {
 
 // directoryServerInstanceResourceModel maps the resource schema data.
 type directoryServerInstanceResourceModel struct {
-	// Id field required for acceptance testing framework
 	Id                         types.String `tfsdk:"id"`
 	ReplicationSetName         types.String `tfsdk:"replication_set_name"`
 	LoadBalancingAlgorithmName types.Set    `tfsdk:"load_balancing_algorithm_name"`
@@ -112,7 +111,7 @@ func (r *directoryServerInstanceResource) Create(ctx context.Context, req resour
 		return
 	}
 
-	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString()).Execute()
+	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -129,7 +128,7 @@ func (r *directoryServerInstanceResource) Create(ctx context.Context, req resour
 	readDirectoryServerInstanceResponse(ctx, getResp.DirectoryServerInstanceResponse, &state)
 
 	// Determine what changes need to be made to match the plan
-	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 	ops := createDirectoryServerInstanceOperations(plan, state)
 
 	if len(ops) > 0 {
@@ -168,8 +167,7 @@ func (r *directoryServerInstanceResource) Create(ctx context.Context, req resour
 // Read a DirectoryServerInstanceResponse object into the model struct.
 // Use empty string for nils since everything is marked as computed.
 func readDirectoryServerInstanceResponse(ctx context.Context, r *client.DirectoryServerInstanceResponse, state *directoryServerInstanceResourceModel) {
-	// Placeholder Id value for acceptance test framework
-	state.Id = types.StringValue(r.ServerInstanceName)
+	state.Id = internaltypes.StringTypeOrNil(r.Id, true)
 	state.ReplicationSetName = internaltypes.StringTypeOrNil(r.ReplicationSetName, true)
 	state.LoadBalancingAlgorithmName = internaltypes.GetStringSet(r.LoadBalancingAlgorithmName)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
@@ -209,7 +207,7 @@ func (r *directoryServerInstanceResource) Read(ctx context.Context, req resource
 		return
 	}
 
-	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.ServerInstanceName.ValueString()).Execute()
+	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -274,7 +272,7 @@ func (r *directoryServerInstanceResource) Update(ctx context.Context, req resour
 	// Get the current state to see how any attributes are changing
 	var state directoryServerInstanceResourceModel
 	req.State.Get(ctx, &state)
-	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 
 	// Determine what update operations are necessary
 	ops := createDirectoryServerInstanceOperations(plan, state)
@@ -318,6 +316,6 @@ func (r *directoryServerInstanceResource) Delete(ctx context.Context, req resour
 }
 
 func (r *directoryServerInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to Name attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/resource/config/serverinstance/proxy_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/proxy_server_instance_resource.go
@@ -67,7 +67,7 @@ func (r *proxyServerInstanceResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString()).Execute()
+	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -84,7 +84,7 @@ func (r *proxyServerInstanceResource) Create(ctx context.Context, req resource.C
 	readProxyServerInstanceResponse(ctx, getResp.ProxyServerInstanceResponse, &state)
 
 	// Determine what changes need to be made to match the plan
-	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 	ops := CreateCommonServerInstanceOperations(plan, state)
 
 	if len(ops) > 0 {
@@ -123,8 +123,7 @@ func (r *proxyServerInstanceResource) Create(ctx context.Context, req resource.C
 // Read a ProxyServerInstanceResponse object into the model struct.
 // Use empty string for nils since everything is marked as computed.
 func readProxyServerInstanceResponse(ctx context.Context, r *client.ProxyServerInstanceResponse, state *CommonServerInstanceResourceModel) {
-	// Placeholder Id value for acceptance test framework
-	state.Id = types.StringValue(r.ServerInstanceName)
+	state.Id = internaltypes.StringTypeOrNil(r.Id, true)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
 	state.ClusterName = types.StringValue(r.ClusterName)
 	state.ServerInstanceLocation = internaltypes.StringTypeOrNil(r.ServerInstanceLocation, true)
@@ -162,7 +161,7 @@ func (r *proxyServerInstanceResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.ServerInstanceName.ValueString()).Execute()
+	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -198,7 +197,7 @@ func (r *proxyServerInstanceResource) Update(ctx context.Context, req resource.U
 	// Get the current state to see how any attributes are changing
 	var state CommonServerInstanceResourceModel
 	req.State.Get(ctx, &state)
-	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 
 	// Determine what update operations are necessary
 	ops := CreateCommonServerInstanceOperations(plan, state)
@@ -242,6 +241,6 @@ func (r *proxyServerInstanceResource) Delete(ctx context.Context, req resource.D
 }
 
 func (r *proxyServerInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to Name attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/resource/config/serverinstance/server_instance_resource_common.go
+++ b/internal/resource/config/serverinstance/server_instance_resource_common.go
@@ -14,7 +14,6 @@ import (
 // resource implementations because they use the exact same model. If they change, they won't be able to share
 // these definitions.
 type CommonServerInstanceResourceModel struct {
-	// Id field required for acceptance testing framework
 	Id                        types.String `tfsdk:"id"`
 	ServerInstanceName        types.String `tfsdk:"server_instance_name"`
 	ClusterName               types.String `tfsdk:"cluster_name"`
@@ -153,7 +152,7 @@ func GetCommonServerInstanceSchema(description string) schema.Schema {
 			},
 		},
 	}
-	config.AddCommonSchema(&schema)
+	config.AddCommonSchema(&schema, true)
 	return schema
 }
 

--- a/internal/resource/config/serverinstance/sync_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/sync_server_instance_resource.go
@@ -67,7 +67,7 @@ func (r *syncServerInstanceResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString()).Execute()
+	getResp, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -84,7 +84,7 @@ func (r *syncServerInstanceResource) Create(ctx context.Context, req resource.Cr
 	readSyncServerInstanceResponse(ctx, getResp.SyncServerInstanceResponse, &state)
 
 	// Determine what changes need to be made to match the plan
-	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateInstanceRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 	ops := CreateCommonServerInstanceOperations(plan, state)
 
 	if len(ops) > 0 {
@@ -123,8 +123,7 @@ func (r *syncServerInstanceResource) Create(ctx context.Context, req resource.Cr
 // Read a SyncServerInstanceResponse object into the model struct.
 // Use empty string for nils since everything is marked as computed.
 func readSyncServerInstanceResponse(ctx context.Context, r *client.SyncServerInstanceResponse, state *CommonServerInstanceResourceModel) {
-	// Placeholder Id value for acceptance test framework
-	state.Id = types.StringValue(r.ServerInstanceName)
+	state.Id = internaltypes.StringTypeOrNil(r.Id, true)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
 	state.ClusterName = types.StringValue(r.ClusterName)
 	state.ServerInstanceLocation = internaltypes.StringTypeOrNil(r.ServerInstanceLocation, true)
@@ -162,7 +161,7 @@ func (r *syncServerInstanceResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.ServerInstanceName.ValueString()).Execute()
+	serverInstanceResponse, httpResp, err := r.apiClient.ServerInstanceApi.GetServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Server Instance", err, httpResp)
 		return
@@ -198,7 +197,7 @@ func (r *syncServerInstanceResource) Update(ctx context.Context, req resource.Up
 	// Get the current state to see how any attributes are changing
 	var state CommonServerInstanceResourceModel
 	req.State.Get(ctx, &state)
-	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.ServerInstanceName.ValueString())
+	updateRequest := r.apiClient.ServerInstanceApi.UpdateServerInstance(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 
 	// Determine what update operations are necessary
 	ops := CreateCommonServerInstanceOperations(plan, state)
@@ -242,6 +241,6 @@ func (r *syncServerInstanceResource) Delete(ctx context.Context, req resource.De
 }
 
 func (r *syncServerInstanceResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to Name attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/resource/config/trustmanagerprovider/file_based_trust_manager_provider_resource.go
+++ b/internal/resource/config/trustmanagerprovider/file_based_trust_manager_provider_resource.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	client "github.com/pingidentity/pingdirectory-go-client/v9100"
@@ -38,9 +36,7 @@ type fileBasedTrustManagerProviderResource struct {
 
 // fileBasedTrustManagerProviderResourceModel maps the resource schema data.
 type fileBasedTrustManagerProviderResourceModel struct {
-	// Id field required for acceptance testing framework
 	Id                              types.String `tfsdk:"id"`
-	Name                            types.String `tfsdk:"name"`
 	TrustStoreFile                  types.String `tfsdk:"trust_store_file"`
 	TrustStoreType                  types.String `tfsdk:"trust_store_type"`
 	TrustStorePin                   types.String `tfsdk:"trust_store_pin"`
@@ -63,13 +59,6 @@ func (r *fileBasedTrustManagerProviderResource) Schema(ctx context.Context, req 
 	schema := schema.Schema{
 		Description: "Manages a File Based Trust Manager Provider.",
 		Attributes: map[string]schema.Attribute{
-			"name": schema.StringAttribute{
-				Description: "Name of the Trust Manager Provider.",
-				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
 			"trust_store_file": schema.StringAttribute{
 				Description: "Specifies the path to the file containing the trust information. It can be an absolute path or a path that is relative to the Directory Server instance root.",
 				Required:    true,
@@ -103,7 +92,7 @@ func (r *fileBasedTrustManagerProviderResource) Schema(ctx context.Context, req 
 			},
 		},
 	}
-	config.AddCommonSchema(&schema)
+	config.AddCommonSchema(&schema, true)
 	resp.Schema = schema
 }
 
@@ -154,7 +143,7 @@ func (r *fileBasedTrustManagerProviderResource) Create(ctx context.Context, req 
 		return
 	}
 
-	addRequest := client.NewAddFileBasedTrustManagerProviderRequest(plan.Name.ValueString(),
+	addRequest := client.NewAddFileBasedTrustManagerProviderRequest(plan.Id.ValueString(),
 		[]client.EnumfileBasedTrustManagerProviderSchemaUrn{client.ENUMFILEBASEDTRUSTMANAGERPROVIDERSCHEMAURN_URNPINGIDENTITYSCHEMASCONFIGURATION2_0TRUST_MANAGER_PROVIDERFILE_BASED},
 		plan.TrustStoreFile.ValueString(),
 		plan.Enabled.ValueBool())
@@ -198,9 +187,7 @@ func (r *fileBasedTrustManagerProviderResource) Create(ctx context.Context, req 
 // Read a FileBasedTrustManagerProviderResponse object into the model struct
 func readFileBasedTrustManagerProviderResponse(ctx context.Context, r *client.FileBasedTrustManagerProviderResponse,
 	state *fileBasedTrustManagerProviderResourceModel, expectedValues *fileBasedTrustManagerProviderResourceModel) {
-	// Placeholder Id value for acceptance test framework
 	state.Id = types.StringValue(r.Id)
-	state.Name = types.StringValue(r.Id)
 	state.TrustStoreFile = types.StringValue(r.TrustStoreFile)
 	// If a plan was provided and is using an empty string, use that for a nil string in the response.
 	// To PingDirectory, nil and empty string is equivalent, but to Terraform they are distinct. So we
@@ -226,7 +213,7 @@ func (r *fileBasedTrustManagerProviderResource) Read(ctx context.Context, req re
 	}
 
 	trustManagerResponse, httpResp, err := r.apiClient.TrustManagerProviderApi.GetTrustManagerProvider(
-		config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Name.ValueString()).Execute()
+		config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Id.ValueString()).Execute()
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while getting the Trust Manager Provider", err, httpResp)
 		return
@@ -275,7 +262,7 @@ func (r *fileBasedTrustManagerProviderResource) Update(ctx context.Context, req 
 	// Get the current state to see how any attributes are changing
 	var state fileBasedTrustManagerProviderResourceModel
 	req.State.Get(ctx, &state)
-	updateRequest := r.apiClient.TrustManagerProviderApi.UpdateTrustManagerProvider(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Name.ValueString())
+	updateRequest := r.apiClient.TrustManagerProviderApi.UpdateTrustManagerProvider(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
 
 	// Determine what update operations are necessary
 	ops := createFileBasedTrustManagerProviderOperations(plan, state)
@@ -322,7 +309,7 @@ func (r *fileBasedTrustManagerProviderResource) Delete(ctx context.Context, req 
 	}
 
 	httpResp, err := r.apiClient.TrustManagerProviderApi.DeleteTrustManagerProviderExecute(
-		r.apiClient.TrustManagerProviderApi.DeleteTrustManagerProvider(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Name.ValueString()))
+		r.apiClient.TrustManagerProviderApi.DeleteTrustManagerProvider(config.ProviderBasicAuthContext(ctx, r.providerConfig), state.Id.ValueString()))
 	if err != nil {
 		config.ReportHttpError(ctx, &resp.Diagnostics, "An error occurred while deleting the Trust Manager Provider", err, httpResp)
 		return
@@ -330,6 +317,6 @@ func (r *fileBasedTrustManagerProviderResource) Delete(ctx context.Context, req 
 }
 
 func (r *fileBasedTrustManagerProviderResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Retrieve import ID and save to Name attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	// Retrieve import ID and save to id attribute
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
Updated to use Id attribute instead of Name for instantiable resources. This prevents the duplication and aligns with what the test framework expects.

BRASS-690