### PR TITLE
Update to client v9100.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/pingidentity/pingdirectory-go-client/v9100 v9100.3.2
+	github.com/pingidentity/pingdirectory-go-client/v9100 v9100.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwb
 github.com/pelletier/go-toml/v2 v2.0.5/go.mod h1:OMHamSCAODeSsVrwwvcJOaoN0LIUIaFVNZzmWyNfXas=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d h1:CdDQnGF8Nq9ocOS/xlSptM1N3BbrA6/kmaep5ggwaIA=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
-github.com/pingidentity/pingdirectory-go-client/v9100 v9100.3.2 h1:rrk1Q6d+TuTEC5AAeHN2s5xp9V7639zzjs2PGiNMZ3M=
-github.com/pingidentity/pingdirectory-go-client/v9100 v9100.3.2/go.mod h1:NQaDweIUfq5eyEFTz9wHNEmCq0pFo72zI/vknd2BCyw=
+github.com/pingidentity/pingdirectory-go-client/v9100 v9100.4.0 h1:IcjM6cfgCb8EzqacctlJnksUL0ykcA1f8ovrxVHRgsE=
+github.com/pingidentity/pingdirectory-go-client/v9100 v9100.4.0/go.mod h1:NQaDweIUfq5eyEFTz9wHNEmCq0pFo72zI/vknd2BCyw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/resource/config/connectionhandler/http_connection_handler_resource.go
+++ b/internal/resource/config/connectionhandler/http_connection_handler_resource.go
@@ -393,7 +393,8 @@ func readHttpConnectionHandlerResponse(ctx context.Context, r *client.HttpConnec
 	state.UseCorrelationIDHeader = internaltypes.BoolTypeOrNil(r.UseCorrelationIDHeader)
 	state.CorrelationIDResponseHeader = internaltypes.StringTypeOrNil(r.CorrelationIDResponseHeader, internaltypes.IsEmptyString(expectedValues.CorrelationIDResponseHeader))
 	state.CorrelationIDRequestHeader = internaltypes.GetStringSet(r.CorrelationIDRequestHeader)
-	state.SslClientAuthPolicy = internaltypes.StringerStringTypeOrNil(r.SslClientAuthPolicy)
+	state.SslClientAuthPolicy = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumconnectionHandlerSslClientAuthPolicyProp(r.SslClientAuthPolicy), true)
 	state.Description = internaltypes.StringTypeOrNil(r.Description, internaltypes.IsEmptyString(expectedValues.Description))
 	state.Enabled = types.BoolValue(r.Enabled)
 	state.Notifications, state.RequiredActions = config.ReadMessages(ctx, r.Urnpingidentityschemasconfigurationmessages20, diagnostics)

--- a/internal/resource/config/connectionhandler/ldap_connection_handler_resource.go
+++ b/internal/resource/config/connectionhandler/ldap_connection_handler_resource.go
@@ -369,7 +369,8 @@ func readLdapConnectionHandlerResponse(ctx context.Context, r *client.LdapConnec
 	state.MaxCancelHandlers = internaltypes.Int64TypeOrNil(r.MaxCancelHandlers)
 	state.NumAcceptHandlers = internaltypes.Int64TypeOrNil(r.NumAcceptHandlers)
 	state.NumRequestHandlers = internaltypes.Int64TypeOrNil(r.NumRequestHandlers)
-	state.SslClientAuthPolicy = internaltypes.StringerStringTypeOrNil(r.SslClientAuthPolicy)
+	state.SslClientAuthPolicy = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumconnectionHandlerSslClientAuthPolicyProp(r.SslClientAuthPolicy), true)
 	state.AcceptBacklog = internaltypes.Int64TypeOrNil(r.AcceptBacklog)
 	state.SslProtocol = internaltypes.GetStringSet(r.SslProtocol)
 	state.SslCipherSuite = internaltypes.GetStringSet(r.SslCipherSuite)

--- a/internal/resource/config/global_configuration_resource.go
+++ b/internal/resource/config/global_configuration_resource.go
@@ -632,14 +632,17 @@ func readGlobalConfigurationResponse(ctx context.Context, r *client.GlobalConfig
 	state.MaximumModificationsPerModifyRequest = internaltypes.Int64TypeOrNil(r.MaximumModificationsPerModifyRequest)
 	state.BackgroundThreadForEachPersistentSearch = internaltypes.BoolTypeOrNil(r.BackgroundThreadForEachPersistentSearch)
 	state.AllowAttributeNameExceptions = internaltypes.BoolTypeOrNil(r.AllowAttributeNameExceptions)
-	state.InvalidAttributeSyntaxBehavior = internaltypes.StringerStringTypeOrNil(r.InvalidAttributeSyntaxBehavior)
+	state.InvalidAttributeSyntaxBehavior = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumglobalConfigurationInvalidAttributeSyntaxBehaviorProp(r.InvalidAttributeSyntaxBehavior), true)
 	state.PermitSyntaxViolationsForAttribute = internaltypes.GetStringSet(r.PermitSyntaxViolationsForAttribute)
-	state.SingleStructuralObjectclassBehavior = internaltypes.StringerStringTypeOrNil(r.SingleStructuralObjectclassBehavior)
+	state.SingleStructuralObjectclassBehavior = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumglobalConfigurationSingleStructuralObjectclassBehaviorProp(r.SingleStructuralObjectclassBehavior), true)
 	state.AttributesModifiableWithIgnoreNoUserModificationRequestControl = internaltypes.GetStringSet(
 		client.StringSliceEnumglobalConfigurationAttributesModifiableWithIgnoreNoUserModificationRequestControlProp(r.AttributesModifiableWithIgnoreNoUserModificationRequestControl))
 	state.MaximumServerOutLogFileSize = internaltypes.StringTypeOrNil(r.MaximumServerOutLogFileSize, true)
 	state.MaximumServerOutLogFileCount = internaltypes.Int64TypeOrNil(r.MaximumServerOutLogFileCount)
-	state.StartupErrorLoggerOutputLocation = internaltypes.StringerStringTypeOrNil(r.StartupErrorLoggerOutputLocation)
+	state.StartupErrorLoggerOutputLocation = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumglobalConfigurationStartupErrorLoggerOutputLocationProp(r.StartupErrorLoggerOutputLocation), true)
 	state.ExitOnJVMError = internaltypes.BoolTypeOrNil(r.ExitOnJVMError)
 	state.ServerErrorResultCode = internaltypes.Int64TypeOrNil(r.ServerErrorResultCode)
 	state.ResultCodeMap = internaltypes.StringTypeOrNil(r.ResultCodeMap, true)
@@ -649,8 +652,10 @@ func readGlobalConfigurationResponse(ctx context.Context, r *client.GlobalConfig
 	state.DuplicateErrorLogTimeLimit = types.StringValue(r.DuplicateErrorLogTimeLimit)
 	state.DuplicateAlertLimit = types.Int64Value(int64(r.DuplicateAlertLimit))
 	state.DuplicateAlertTimeLimit = types.StringValue(r.DuplicateAlertTimeLimit)
-	state.WritabilityMode = internaltypes.StringerStringTypeOrNil(r.WritabilityMode)
-	state.UnrecoverableDatabaseErrorMode = internaltypes.StringerStringTypeOrNil(r.UnrecoverableDatabaseErrorMode)
+	state.WritabilityMode = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumglobalConfigurationWritabilityModeProp(r.WritabilityMode), true)
+	state.UnrecoverableDatabaseErrorMode = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumglobalConfigurationUnrecoverableDatabaseErrorModeProp(r.UnrecoverableDatabaseErrorMode), true)
 	state.DatabaseOnVirtualizedOrNetworkStorage = internaltypes.BoolTypeOrNil(r.DatabaseOnVirtualizedOrNetworkStorage)
 	state.AutoNameWithEntryUUIDConnectionCriteria = internaltypes.StringTypeOrNil(r.AutoNameWithEntryUUIDConnectionCriteria, true)
 	state.AutoNameWithEntryUUIDRequestCriteria = internaltypes.StringTypeOrNil(r.AutoNameWithEntryUUIDRequestCriteria, true)
@@ -677,7 +682,8 @@ func readGlobalConfigurationResponse(ctx context.Context, r *client.GlobalConfig
 	state.NetworkAddressCacheTTL = internaltypes.StringTypeOrNil(r.NetworkAddressCacheTTL, true)
 	state.NetworkAddressOutageCacheEnabled = internaltypes.BoolTypeOrNil(r.NetworkAddressOutageCacheEnabled)
 	state.TrackedApplication = internaltypes.GetStringSet(r.TrackedApplication)
-	state.JmxValueBehavior = internaltypes.StringerStringTypeOrNil(r.JmxValueBehavior)
+	state.JmxValueBehavior = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumglobalConfigurationJmxValueBehaviorProp(r.JmxValueBehavior), true)
 	state.JmxUseLegacyMbeanNames = internaltypes.BoolTypeOrNil(r.JmxUseLegacyMbeanNames)
 	state.Notifications, state.RequiredActions = ReadMessages(ctx, r.Urnpingidentityschemasconfigurationmessages20, diagnostics)
 }

--- a/internal/resource/config/serverinstance/authorize_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/authorize_server_instance_resource.go
@@ -201,7 +201,8 @@ func (r *authorizeServerInstanceResource) Schema(ctx context.Context, req resour
 // Read a AuthorizeServerInstanceResponse object into the model struct
 func readAuthorizeServerInstanceResponse(ctx context.Context, r *client.AuthorizeServerInstanceResponse, state *authorizeServerInstanceResourceModel, diagnostics *diag.Diagnostics) {
 	state.Id = types.StringValue(r.Id)
-	state.ServerInstanceType = internaltypes.StringerStringTypeOrNil(r.ServerInstanceType)
+	state.ServerInstanceType = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstanceServerInstanceTypeProp(r.ServerInstanceType), true)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
 	state.ClusterName = types.StringValue(r.ClusterName)
 	state.ServerInstanceLocation = internaltypes.StringTypeOrNil(r.ServerInstanceLocation, true)
@@ -218,7 +219,8 @@ func readAuthorizeServerInstanceResponse(ctx context.Context, r *client.Authoriz
 	state.ReplicationDomainServerID = internaltypes.GetInt64Set(r.ReplicationDomainServerID)
 	state.JmxPort = internaltypes.Int64TypeOrNil(r.JmxPort)
 	state.JmxsPort = internaltypes.Int64TypeOrNil(r.JmxsPort)
-	state.PreferredSecurity = internaltypes.StringerStringTypeOrNil(r.PreferredSecurity)
+	state.PreferredSecurity = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstancePreferredSecurityProp(r.PreferredSecurity), true)
 	state.StartTLSEnabled = internaltypes.BoolTypeOrNil(r.StartTLSEnabled)
 	state.BaseDN = internaltypes.GetStringSet(r.BaseDN)
 	state.MemberOfServerGroup = internaltypes.GetStringSet(r.MemberOfServerGroup)

--- a/internal/resource/config/serverinstance/directory_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/directory_server_instance_resource.go
@@ -214,7 +214,8 @@ func (r *directoryServerInstanceResource) Schema(ctx context.Context, req resour
 // Read a DirectoryServerInstanceResponse object into the model struct
 func readDirectoryServerInstanceResponse(ctx context.Context, r *client.DirectoryServerInstanceResponse, state *directoryServerInstanceResourceModel, diagnostics *diag.Diagnostics) {
 	state.Id = types.StringValue(r.Id)
-	state.ServerInstanceType = internaltypes.StringerStringTypeOrNil(r.ServerInstanceType)
+	state.ServerInstanceType = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstanceServerInstanceTypeProp(r.ServerInstanceType), true)
 	state.ReplicationSetName = internaltypes.StringTypeOrNil(r.ReplicationSetName, true)
 	state.LoadBalancingAlgorithmName = internaltypes.GetStringSet(r.LoadBalancingAlgorithmName)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
@@ -233,7 +234,8 @@ func readDirectoryServerInstanceResponse(ctx context.Context, r *client.Director
 	state.ReplicationDomainServerID = internaltypes.GetInt64Set(r.ReplicationDomainServerID)
 	state.JmxPort = internaltypes.Int64TypeOrNil(r.JmxPort)
 	state.JmxsPort = internaltypes.Int64TypeOrNil(r.JmxsPort)
-	state.PreferredSecurity = internaltypes.StringerStringTypeOrNil(r.PreferredSecurity)
+	state.PreferredSecurity = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstancePreferredSecurityProp(r.PreferredSecurity), true)
 	state.StartTLSEnabled = internaltypes.BoolTypeOrNil(r.StartTLSEnabled)
 	state.BaseDN = internaltypes.GetStringSet(r.BaseDN)
 	state.MemberOfServerGroup = internaltypes.GetStringSet(r.MemberOfServerGroup)

--- a/internal/resource/config/serverinstance/proxy_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/proxy_server_instance_resource.go
@@ -201,7 +201,8 @@ func (r *proxyServerInstanceResource) Schema(ctx context.Context, req resource.S
 // Read a ProxyServerInstanceResponse object into the model struct
 func readProxyServerInstanceResponse(ctx context.Context, r *client.ProxyServerInstanceResponse, state *proxyServerInstanceResourceModel, diagnostics *diag.Diagnostics) {
 	state.Id = types.StringValue(r.Id)
-	state.ServerInstanceType = internaltypes.StringerStringTypeOrNil(r.ServerInstanceType)
+	state.ServerInstanceType = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstanceServerInstanceTypeProp(r.ServerInstanceType), true)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
 	state.ClusterName = types.StringValue(r.ClusterName)
 	state.ServerInstanceLocation = internaltypes.StringTypeOrNil(r.ServerInstanceLocation, true)
@@ -218,7 +219,8 @@ func readProxyServerInstanceResponse(ctx context.Context, r *client.ProxyServerI
 	state.ReplicationDomainServerID = internaltypes.GetInt64Set(r.ReplicationDomainServerID)
 	state.JmxPort = internaltypes.Int64TypeOrNil(r.JmxPort)
 	state.JmxsPort = internaltypes.Int64TypeOrNil(r.JmxsPort)
-	state.PreferredSecurity = internaltypes.StringerStringTypeOrNil(r.PreferredSecurity)
+	state.PreferredSecurity = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstancePreferredSecurityProp(r.PreferredSecurity), true)
 	state.StartTLSEnabled = internaltypes.BoolTypeOrNil(r.StartTLSEnabled)
 	state.BaseDN = internaltypes.GetStringSet(r.BaseDN)
 	state.MemberOfServerGroup = internaltypes.GetStringSet(r.MemberOfServerGroup)

--- a/internal/resource/config/serverinstance/sync_server_instance_resource.go
+++ b/internal/resource/config/serverinstance/sync_server_instance_resource.go
@@ -201,7 +201,8 @@ func (r *syncServerInstanceResource) Schema(ctx context.Context, req resource.Sc
 // Read a SyncServerInstanceResponse object into the model struct
 func readSyncServerInstanceResponse(ctx context.Context, r *client.SyncServerInstanceResponse, state *syncServerInstanceResourceModel, diagnostics *diag.Diagnostics) {
 	state.Id = types.StringValue(r.Id)
-	state.ServerInstanceType = internaltypes.StringerStringTypeOrNil(r.ServerInstanceType)
+	state.ServerInstanceType = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstanceServerInstanceTypeProp(r.ServerInstanceType), true)
 	state.ServerInstanceName = types.StringValue(r.ServerInstanceName)
 	state.ClusterName = types.StringValue(r.ClusterName)
 	state.ServerInstanceLocation = internaltypes.StringTypeOrNil(r.ServerInstanceLocation, true)
@@ -218,7 +219,8 @@ func readSyncServerInstanceResponse(ctx context.Context, r *client.SyncServerIns
 	state.ReplicationDomainServerID = internaltypes.GetInt64Set(r.ReplicationDomainServerID)
 	state.JmxPort = internaltypes.Int64TypeOrNil(r.JmxPort)
 	state.JmxsPort = internaltypes.Int64TypeOrNil(r.JmxsPort)
-	state.PreferredSecurity = internaltypes.StringerStringTypeOrNil(r.PreferredSecurity)
+	state.PreferredSecurity = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumserverInstancePreferredSecurityProp(r.PreferredSecurity), true)
 	state.StartTLSEnabled = internaltypes.BoolTypeOrNil(r.StartTLSEnabled)
 	state.BaseDN = internaltypes.GetStringSet(r.BaseDN)
 	state.MemberOfServerGroup = internaltypes.GetStringSet(r.MemberOfServerGroup)

--- a/internal/resource/config/topology_admin_user_resource.go
+++ b/internal/resource/config/topology_admin_user_resource.go
@@ -442,7 +442,8 @@ func readTopologyAdminUserResponse(ctx context.Context, r *client.TopologyAdminU
 	state.AllowedAuthenticationType = internaltypes.GetStringSet(r.AllowedAuthenticationType)
 	state.AllowedAuthenticationIPAddress = internaltypes.GetStringSet(r.AllowedAuthenticationIPAddress)
 	state.PreferredOTPDeliveryMechanism = internaltypes.GetStringSet(r.PreferredOTPDeliveryMechanism)
-	state.IsProxyable = internaltypes.StringerStringTypeOrNil(r.IsProxyable)
+	state.IsProxyable = internaltypes.StringTypeOrNil(
+		client.StringPointerEnumtopologyAdminUserIsProxyableProp(r.IsProxyable), true)
 	state.IsProxyableByDN = internaltypes.GetStringSet(r.IsProxyableByDN)
 	state.IsProxyableByGroup = internaltypes.GetStringSet(r.IsProxyableByGroup)
 	state.IsProxyableByURL = internaltypes.GetStringSet(r.IsProxyableByURL)

--- a/internal/types/conversion.go
+++ b/internal/types/conversion.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -74,14 +73,4 @@ func Float64TypeOrNil(f *float32) types.Float64 {
 	}
 
 	return types.Float64Value(float64(*f))
-}
-
-// Get a types.String from the given Stringer, handling if the pointer is nil
-func StringerStringTypeOrNil(value fmt.Stringer) types.String {
-	// Similar to the StringTypeOrNil method - use an empty string for nil values
-	if value != nil {
-		return types.StringValue(value.String())
-	} else {
-		return types.StringValue("")
-	}
 }


### PR DESCRIPTION
Update to client v9100.4.0, and use the new client helper methods to handle enum pointers, instead of trying to check if a Stringer interface is nil.