### PR TITLE
Ignore API response value for sensitive attributes, since PD does not…

### DIFF
--- a/internal/resource/config/externalserver/active_directory_external_server_resource.go
+++ b/internal/resource/config/externalserver/active_directory_external_server_resource.go
@@ -314,7 +314,8 @@ func readActiveDirectoryExternalServerResponse(ctx context.Context, r *client.Ac
 	state.ServerHostName = types.StringValue(r.ServerHostName)
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/amazon_aws_external_server_resource.go
+++ b/internal/resource/config/externalserver/amazon_aws_external_server_resource.go
@@ -113,7 +113,8 @@ func addOptionalAmazonAwsExternalServerFields(ctx context.Context, addRequest *c
 func readAmazonAwsExternalServerResponse(ctx context.Context, r *client.AmazonAwsExternalServerResponse, state *amazonAwsExternalServerResourceModel, expectedValues *amazonAwsExternalServerResourceModel, diagnostics *diag.Diagnostics) {
 	state.Id = types.StringValue(r.Id)
 	state.AwsAccessKeyID = internaltypes.StringTypeOrNil(r.AwsAccessKeyID, internaltypes.IsEmptyString(expectedValues.AwsAccessKeyID))
-	state.AwsSecretAccessKey = internaltypes.StringTypeOrNil(r.AwsSecretAccessKey, internaltypes.IsEmptyString(expectedValues.AwsSecretAccessKey))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.AwsSecretAccessKey = expectedValues.AwsSecretAccessKey
 	state.AwsRegionName = types.StringValue(r.AwsRegionName)
 	state.Description = internaltypes.StringTypeOrNil(r.Description, internaltypes.IsEmptyString(expectedValues.Description))
 	state.Notifications, state.RequiredActions = config.ReadMessages(ctx, r.Urnpingidentityschemasconfigurationmessages20, diagnostics)

--- a/internal/resource/config/externalserver/conjur_external_server_resource.go
+++ b/internal/resource/config/externalserver/conjur_external_server_resource.go
@@ -138,7 +138,8 @@ func readConjurExternalServerResponse(ctx context.Context, r *client.ConjurExter
 	state.ConjurAuthenticationMethod = types.StringValue(r.ConjurAuthenticationMethod)
 	state.ConjurAccountName = types.StringValue(r.ConjurAccountName)
 	state.TrustStoreFile = internaltypes.StringTypeOrNil(r.TrustStoreFile, internaltypes.IsEmptyString(expectedValues.TrustStoreFile))
-	state.TrustStorePin = internaltypes.StringTypeOrNil(r.TrustStorePin, internaltypes.IsEmptyString(expectedValues.TrustStorePin))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.TrustStorePin = expectedValues.TrustStorePin
 	state.TrustStoreType = internaltypes.StringTypeOrNil(r.TrustStoreType, internaltypes.IsEmptyString(expectedValues.TrustStoreType))
 	state.Description = internaltypes.StringTypeOrNil(r.Description, internaltypes.IsEmptyString(expectedValues.Description))
 	state.Notifications, state.RequiredActions = config.ReadMessages(ctx, r.Urnpingidentityschemasconfigurationmessages20, diagnostics)

--- a/internal/resource/config/externalserver/jdbc_external_server_resource.go
+++ b/internal/resource/config/externalserver/jdbc_external_server_resource.go
@@ -215,7 +215,8 @@ func readJdbcExternalServerResponse(ctx context.Context, r *client.JdbcExternalS
 	state.ServerHostName = internaltypes.StringTypeOrNil(r.ServerHostName, internaltypes.IsEmptyString(expectedValues.ServerHostName))
 	state.ServerPort = internaltypes.Int64TypeOrNil(r.ServerPort)
 	state.UserName = internaltypes.StringTypeOrNil(r.UserName, internaltypes.IsEmptyString(expectedValues.UserName))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ValidationQuery = internaltypes.StringTypeOrNil(r.ValidationQuery, internaltypes.IsEmptyString(expectedValues.ValidationQuery))
 	state.ValidationQueryTimeout = internaltypes.StringTypeOrNil(r.ValidationQueryTimeout, internaltypes.IsEmptyString(expectedValues.ValidationQueryTimeout))

--- a/internal/resource/config/externalserver/ldap_external_server_resource.go
+++ b/internal/resource/config/externalserver/ldap_external_server_resource.go
@@ -314,7 +314,8 @@ func readLdapExternalServerResponse(ctx context.Context, r *client.LdapExternalS
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/nokia_ds_external_server_resource.go
+++ b/internal/resource/config/externalserver/nokia_ds_external_server_resource.go
@@ -326,7 +326,8 @@ func readNokiaDsExternalServerResponse(ctx context.Context, r *client.NokiaDsExt
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/nokia_proxy_server_external_server_resource.go
+++ b/internal/resource/config/externalserver/nokia_proxy_server_external_server_resource.go
@@ -326,7 +326,8 @@ func readNokiaProxyServerExternalServerResponse(ctx context.Context, r *client.N
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/opendj_external_server_resource.go
+++ b/internal/resource/config/externalserver/opendj_external_server_resource.go
@@ -314,7 +314,8 @@ func readOpendjExternalServerResponse(ctx context.Context, r *client.OpendjExter
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/oracle_unified_directory_external_server_resource.go
+++ b/internal/resource/config/externalserver/oracle_unified_directory_external_server_resource.go
@@ -314,7 +314,8 @@ func readOracleUnifiedDirectoryExternalServerResponse(ctx context.Context, r *cl
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/ping_identity_ds_external_server_resource.go
+++ b/internal/resource/config/externalserver/ping_identity_ds_external_server_resource.go
@@ -326,7 +326,8 @@ func readPingIdentityDsExternalServerResponse(ctx context.Context, r *client.Pin
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/ping_identity_proxy_server_external_server_resource.go
+++ b/internal/resource/config/externalserver/ping_identity_proxy_server_external_server_resource.go
@@ -326,7 +326,8 @@ func readPingIdentityProxyServerExternalServerResponse(ctx context.Context, r *c
 	state.ServerPort = types.Int64Value(int64(r.ServerPort))
 	state.Location = internaltypes.StringTypeOrNil(r.Location, internaltypes.IsEmptyString(expectedValues.Location))
 	state.BindDN = internaltypes.StringTypeOrNil(r.BindDN, internaltypes.IsEmptyString(expectedValues.BindDN))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.ConnectionSecurity = types.StringValue(r.ConnectionSecurity.String())
 	state.AuthenticationMethod = types.StringValue(r.AuthenticationMethod.String())

--- a/internal/resource/config/externalserver/smtp_external_server_resource.go
+++ b/internal/resource/config/externalserver/smtp_external_server_resource.go
@@ -175,7 +175,8 @@ func readSmtpExternalServerResponse(ctx context.Context, r *client.SmtpExternalS
 	state.SmtpSecurity = internaltypes.StringTypeOrNil(
 		client.StringPointerEnumexternalServerSmtpSecurityProp(r.SmtpSecurity), internaltypes.IsEmptyString(expectedValues.SmtpSecurity))
 	state.UserName = internaltypes.StringTypeOrNil(r.UserName, internaltypes.IsEmptyString(expectedValues.UserName))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.PassphraseProvider = internaltypes.StringTypeOrNil(r.PassphraseProvider, internaltypes.IsEmptyString(expectedValues.PassphraseProvider))
 	state.SmtpTimeout = internaltypes.StringTypeOrNil(r.SmtpTimeout, internaltypes.IsEmptyString(expectedValues.SmtpTimeout))
 	config.CheckMismatchedPDFormattedAttributes("smtp_timeout",

--- a/internal/resource/config/externalserver/vault_external_server_resource.go
+++ b/internal/resource/config/externalserver/vault_external_server_resource.go
@@ -132,7 +132,8 @@ func readVaultExternalServerResponse(ctx context.Context, r *client.VaultExterna
 	state.VaultServerBaseURI = internaltypes.GetStringSet(r.VaultServerBaseURI)
 	state.VaultAuthenticationMethod = types.StringValue(r.VaultAuthenticationMethod)
 	state.TrustStoreFile = internaltypes.StringTypeOrNil(r.TrustStoreFile, internaltypes.IsEmptyString(expectedValues.TrustStoreFile))
-	state.TrustStorePin = internaltypes.StringTypeOrNil(r.TrustStorePin, internaltypes.IsEmptyString(expectedValues.TrustStorePin))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.TrustStorePin = expectedValues.TrustStorePin
 	state.TrustStoreType = internaltypes.StringTypeOrNil(r.TrustStoreType, internaltypes.IsEmptyString(expectedValues.TrustStoreType))
 	state.Description = internaltypes.StringTypeOrNil(r.Description, internaltypes.IsEmptyString(expectedValues.Description))
 	state.Notifications, state.RequiredActions = config.ReadMessages(ctx, r.Urnpingidentityschemasconfigurationmessages20, diagnostics)

--- a/internal/resource/config/plugin/changelog_password_encryption_plugin_resource.go
+++ b/internal/resource/config/plugin/changelog_password_encryption_plugin_resource.go
@@ -108,9 +108,10 @@ func (r *changelogPasswordEncryptionPluginResource) Schema(ctx context.Context, 
 }
 
 // Read a ChangelogPasswordEncryptionPluginResponse object into the model struct
-func readChangelogPasswordEncryptionPluginResponse(ctx context.Context, r *client.ChangelogPasswordEncryptionPluginResponse, state *changelogPasswordEncryptionPluginResourceModel, diagnostics *diag.Diagnostics) {
+func readChangelogPasswordEncryptionPluginResponse(ctx context.Context, r *client.ChangelogPasswordEncryptionPluginResponse, state *changelogPasswordEncryptionPluginResourceModel, expectedValues *changelogPasswordEncryptionPluginResourceModel, diagnostics *diag.Diagnostics) {
 	state.Id = types.StringValue(r.Id)
-	state.ChangelogPasswordEncryptionKey = internaltypes.StringTypeOrNil(r.ChangelogPasswordEncryptionKey, true)
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.ChangelogPasswordEncryptionKey = expectedValues.ChangelogPasswordEncryptionKey
 	state.ChangelogPasswordEncryptionKeyPassphraseProvider = internaltypes.StringTypeOrNil(r.ChangelogPasswordEncryptionKeyPassphraseProvider, true)
 	state.PluginType = internaltypes.GetStringSet(
 		client.StringSliceEnumpluginPluginTypeProp(r.PluginType))
@@ -160,7 +161,7 @@ func (r *changelogPasswordEncryptionPluginResource) Create(ctx context.Context, 
 
 	// Read the existing configuration
 	var state changelogPasswordEncryptionPluginResourceModel
-	readChangelogPasswordEncryptionPluginResponse(ctx, readResponse.ChangelogPasswordEncryptionPluginResponse, &state, &resp.Diagnostics)
+	readChangelogPasswordEncryptionPluginResponse(ctx, readResponse.ChangelogPasswordEncryptionPluginResponse, &state, &state, &resp.Diagnostics)
 
 	// Determine what changes are needed to match the plan
 	updateRequest := r.apiClient.PluginApi.UpdatePlugin(config.ProviderBasicAuthContext(ctx, r.providerConfig), plan.Id.ValueString())
@@ -183,7 +184,7 @@ func (r *changelogPasswordEncryptionPluginResource) Create(ctx context.Context, 
 		}
 
 		// Read the response
-		readChangelogPasswordEncryptionPluginResponse(ctx, updateResponse.ChangelogPasswordEncryptionPluginResponse, &state, &resp.Diagnostics)
+		readChangelogPasswordEncryptionPluginResponse(ctx, updateResponse.ChangelogPasswordEncryptionPluginResponse, &state, &plan, &resp.Diagnostics)
 		// Update computed values
 		state.LastUpdated = types.StringValue(string(time.Now().Format(time.RFC850)))
 	}
@@ -219,7 +220,7 @@ func (r *changelogPasswordEncryptionPluginResource) Read(ctx context.Context, re
 	}
 
 	// Read the response into the state
-	readChangelogPasswordEncryptionPluginResponse(ctx, readResponse.ChangelogPasswordEncryptionPluginResponse, &state, &resp.Diagnostics)
+	readChangelogPasswordEncryptionPluginResponse(ctx, readResponse.ChangelogPasswordEncryptionPluginResponse, &state, &state, &resp.Diagnostics)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
@@ -265,7 +266,7 @@ func (r *changelogPasswordEncryptionPluginResource) Update(ctx context.Context, 
 		}
 
 		// Read the response
-		readChangelogPasswordEncryptionPluginResponse(ctx, updateResponse.ChangelogPasswordEncryptionPluginResponse, &state, &resp.Diagnostics)
+		readChangelogPasswordEncryptionPluginResponse(ctx, updateResponse.ChangelogPasswordEncryptionPluginResponse, &state, &plan, &resp.Diagnostics)
 		// Update computed values
 		state.LastUpdated = types.StringValue(string(time.Now().Format(time.RFC850)))
 	} else {

--- a/internal/resource/config/plugin/ping_one_pass_through_authentication_plugin_resource.go
+++ b/internal/resource/config/plugin/ping_one_pass_through_authentication_plugin_resource.go
@@ -270,7 +270,8 @@ func readPingOnePassThroughAuthenticationPluginResponse(ctx context.Context, r *
 	state.ApiURL = types.StringValue(r.ApiURL)
 	state.AuthURL = types.StringValue(r.AuthURL)
 	state.OAuthClientID = types.StringValue(r.OAuthClientID)
-	state.OAuthClientSecret = internaltypes.StringTypeOrNil(r.OAuthClientSecret, internaltypes.IsEmptyString(expectedValues.OAuthClientSecret))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.OAuthClientSecret = expectedValues.OAuthClientSecret
 	state.OAuthClientSecretPassphraseProvider = internaltypes.StringTypeOrNil(r.OAuthClientSecretPassphraseProvider, internaltypes.IsEmptyString(expectedValues.OAuthClientSecretPassphraseProvider))
 	state.EnvironmentID = types.StringValue(r.EnvironmentID)
 	state.IncludedLocalEntryBaseDN = internaltypes.GetStringSet(r.IncludedLocalEntryBaseDN)

--- a/internal/resource/config/root_dn_user_resource.go
+++ b/internal/resource/config/root_dn_user_resource.go
@@ -458,7 +458,8 @@ func readRootDnUserResponse(ctx context.Context, r *client.RootDnUserResponse, s
 	state.Id = types.StringValue(r.Id)
 	state.AlternateBindDN = internaltypes.GetStringSet(r.AlternateBindDN)
 	state.Description = internaltypes.StringTypeOrNil(r.Description, internaltypes.IsEmptyString(expectedValues.Description))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.FirstName = internaltypes.GetStringSet(r.FirstName)
 	state.LastName = internaltypes.GetStringSet(r.LastName)
 	state.UserID = internaltypes.StringTypeOrNil(r.UserID, internaltypes.IsEmptyString(expectedValues.UserID))

--- a/internal/resource/config/topology_admin_user_resource.go
+++ b/internal/resource/config/topology_admin_user_resource.go
@@ -458,7 +458,8 @@ func readTopologyAdminUserResponse(ctx context.Context, r *client.TopologyAdminU
 	state.Id = types.StringValue(r.Id)
 	state.AlternateBindDN = internaltypes.GetStringSet(r.AlternateBindDN)
 	state.Description = internaltypes.StringTypeOrNil(r.Description, internaltypes.IsEmptyString(expectedValues.Description))
-	state.Password = internaltypes.StringTypeOrNil(r.Password, internaltypes.IsEmptyString(expectedValues.Password))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.Password = expectedValues.Password
 	state.FirstName = internaltypes.GetStringSet(r.FirstName)
 	state.LastName = internaltypes.GetStringSet(r.LastName)
 	state.UserID = internaltypes.StringTypeOrNil(r.UserID, internaltypes.IsEmptyString(expectedValues.UserID))

--- a/internal/resource/config/trustmanagerprovider/file_based_trust_manager_provider_resource.go
+++ b/internal/resource/config/trustmanagerprovider/file_based_trust_manager_provider_resource.go
@@ -139,7 +139,8 @@ func readFileBasedTrustManagerProviderResponse(ctx context.Context, r *client.Fi
 	state.Id = types.StringValue(r.Id)
 	state.TrustStoreFile = types.StringValue(r.TrustStoreFile)
 	state.TrustStoreType = internaltypes.StringTypeOrNil(r.TrustStoreType, internaltypes.IsEmptyString(expectedValues.TrustStoreType))
-	state.TrustStorePin = internaltypes.StringTypeOrNil(r.TrustStorePin, internaltypes.IsEmptyString(expectedValues.TrustStorePin))
+	// Obscured values aren't returned from the PD Configuration API - just use the expected value
+	state.TrustStorePin = expectedValues.TrustStorePin
 	state.TrustStorePinFile = internaltypes.StringTypeOrNil(r.TrustStorePinFile, internaltypes.IsEmptyString(expectedValues.TrustStorePinFile))
 	state.TrustStorePinPassphraseProvider = internaltypes.StringTypeOrNil(r.TrustStorePinPassphraseProvider, internaltypes.IsEmptyString(expectedValues.TrustStorePinPassphraseProvider))
 	state.Enabled = types.BoolValue(r.Enabled)


### PR DESCRIPTION
… return them in the clear