### PR TITLE
Mark attributes required for specific types

### DIFF
--- a/internal/configvalidators/implies_other_attribute_one_of_string_config_validator.go
+++ b/internal/configvalidators/implies_other_attribute_one_of_string_config_validator.go
@@ -36,8 +36,8 @@ func (v ImpliesOtherAttributeOneOfStringValidator) Description(ctx context.Conte
 }
 
 func (v ImpliesOtherAttributeOneOfStringValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("If the \"%s\" attribute is configured, then the \"%s\" attribute must have one of the following values if it is configured: %v",
-		v.Condition, v.Implied, v.ImpliedAllowedValues)
+	return fmt.Sprintf("If the \"%s\" attribute is configured, then the \"%s\" attribute must have one of the following values if it is configured: %s",
+		v.Condition, v.Implied, stringSliceToReadableString(v.ImpliedAllowedValues))
 }
 
 func (v ImpliesOtherAttributeOneOfStringValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/internal/configvalidators/implies_other_validator_validator.go
+++ b/internal/configvalidators/implies_other_validator_validator.go
@@ -35,8 +35,8 @@ func (v ImpliesOtherValidatorValidator) Description(ctx context.Context) string 
 }
 
 func (v ImpliesOtherValidatorValidator) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("If the \"%s\" attribute is configured with one of the following values: %v, then the following validator check must pass: %s",
-		v.Condition, v.ConditionValues, v.Implied.MarkdownDescription(ctx))
+	return fmt.Sprintf("If the \"%s\" attribute is configured with one of the following values: %s, then the following validator check must pass: %s",
+		v.Condition, stringSliceToReadableString(v.ConditionValues), v.Implied.MarkdownDescription(ctx))
 }
 
 func (v ImpliesOtherValidatorValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/internal/configvalidators/utils.go
+++ b/internal/configvalidators/utils.go
@@ -1,0 +1,30 @@
+package configvalidators
+
+import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+)
+
+func stringSliceToReadableString(slice []string) string {
+	var output strings.Builder
+	output.WriteRune('[')
+	for i, str := range slice {
+		if i > 0 {
+			output.WriteString(", ")
+		}
+		output.WriteRune('"')
+		output.WriteString(str)
+		output.WriteRune('"')
+	}
+	output.WriteRune(']')
+	return output.String()
+}
+
+func pathExpressionSliceToReadableString(slice []path.Expression) string {
+	stringSlice := []string{}
+	for _, pathExpr := range slice {
+		stringSlice = append(stringSlice, pathExpr.String())
+	}
+	return stringSliceToReadableString(stringSlice)
+}

--- a/internal/configvalidators/value_implies_attribute_required_config_validator.go
+++ b/internal/configvalidators/value_implies_attribute_required_config_validator.go
@@ -14,20 +14,20 @@ import (
 var _ resource.ConfigValidator = &ValueImpliesAttributeRequiredValidator{}
 
 // Create a ValueImpliesAttributeRequiredValidator indicating that the implied attribute paths are required to be configured if the
-// condition string attribute is configured with one of the given values
-func ValueImpliesAttributeRequired(condition path.Expression, conditionValues []string, implied []path.Expression) resource.ConfigValidator {
+// condition string attribute is configured with condition value
+func ValueImpliesAttributeRequired(condition path.Expression, conditionValue string, implied []path.Expression) resource.ConfigValidator {
 	return ValueImpliesAttributeRequiredValidator{
-		Condition:       condition,
-		ConditionValues: conditionValues,
-		Implied:         implied,
+		Condition:      condition,
+		ConditionValue: conditionValue,
+		Implied:        implied,
 	}
 }
 
 // ImpliesValidator is the underlying struct implementing Implies.
 type ValueImpliesAttributeRequiredValidator struct {
-	Condition       path.Expression
-	ConditionValues []string
-	Implied         []path.Expression
+	Condition      path.Expression
+	ConditionValue string
+	Implied        []path.Expression
 }
 
 func (v ValueImpliesAttributeRequiredValidator) Description(ctx context.Context) string {
@@ -35,7 +35,7 @@ func (v ValueImpliesAttributeRequiredValidator) Description(ctx context.Context)
 }
 
 func (v ValueImpliesAttributeRequiredValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("The %s attribute(s) must be configured if the \"%s\" attribute is configured with one of the following values: %s", pathExpressionSliceToReadableString(v.Implied), v.Condition, stringSliceToReadableString(v.ConditionValues))
+	return fmt.Sprintf("The %s attribute(s) must be configured if the \"%s\" attribute is configured with the following value: \"%s\"", pathExpressionSliceToReadableString(v.Implied), v.Condition, v.ConditionValue)
 }
 
 func (v ValueImpliesAttributeRequiredValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
@@ -81,14 +81,9 @@ func (v ValueImpliesAttributeRequiredValidator) ValidateResource(ctx context.Con
 			return
 		}
 
-		for _, allowedValue := range v.ConditionValues {
-			if allowedValue == conditionValueString.ValueString() {
-				// Condition string value found, continue
-				conditionValueMatch = true
-				break
-			}
-		}
-		if conditionValueMatch {
+		if v.ConditionValue == conditionValueString.ValueString() {
+			// Condition string value found, continue
+			conditionValueMatch = true
 			break
 		}
 	}

--- a/internal/configvalidators/value_implies_attribute_required_config_validator.go
+++ b/internal/configvalidators/value_implies_attribute_required_config_validator.go
@@ -1,0 +1,143 @@
+package configvalidators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.ConfigValidator = &ValueImpliesAttributeRequiredValidator{}
+
+// Create a ValueImpliesAttributeRequiredValidator indicating that the implied attribute paths are required to be configured if the
+// condition string attribute is configured with one of the given values
+func ValueImpliesAttributeRequired(condition path.Expression, conditionValues []string, implied []path.Expression) resource.ConfigValidator {
+	return ValueImpliesAttributeRequiredValidator{
+		Condition:       condition,
+		ConditionValues: conditionValues,
+		Implied:         implied,
+	}
+}
+
+// ImpliesValidator is the underlying struct implementing Implies.
+type ValueImpliesAttributeRequiredValidator struct {
+	Condition       path.Expression
+	ConditionValues []string
+	Implied         []path.Expression
+}
+
+func (v ValueImpliesAttributeRequiredValidator) Description(ctx context.Context) string {
+	return v.MarkdownDescription(ctx)
+}
+
+func (v ValueImpliesAttributeRequiredValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("The %s attribute(s) must be configured if the \"%s\" attribute is configured with one of the following values: %s", pathExpressionSliceToReadableString(v.Implied), v.Condition, stringSliceToReadableString(v.ConditionValues))
+}
+
+func (v ValueImpliesAttributeRequiredValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var conditionValue, impliedValue attr.Value
+
+	// Check for the condition attribute
+	conditionMatchedPaths, conditionDiags := req.Config.PathMatches(ctx, v.Condition)
+
+	resp.Diagnostics.Append(conditionDiags...)
+	if conditionDiags.HasError() {
+		return
+	}
+
+	conditionValueMatch := false
+	for _, matchedPath := range conditionMatchedPaths {
+		getAttributeDiags := req.Config.GetAttribute(ctx, matchedPath, &conditionValue)
+
+		resp.Diagnostics.Append(getAttributeDiags...)
+		if getAttributeDiags.HasError() {
+			return
+		}
+
+		// If value is unknown, it may be null or a value, so we cannot
+		// know if the validator should succeed or not. Collect the path
+		// path so we use it to skip the validation later and continue to
+		// collect all path matching diagnostics.
+		if conditionValue.IsUnknown() {
+			return
+		}
+
+		// If the condition is null, then try the next match
+		if conditionValue.IsNull() {
+			continue
+		}
+
+		// Value is known and not null, so we need to check if it is one of the condition values
+		conditionValueString, ok := conditionValue.(types.String)
+		if !ok {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+				fmt.Sprintf("\"%s\" attribute has non-string value", v.Implied),
+				v.Description(ctx),
+			))
+			return
+		}
+
+		for _, allowedValue := range v.ConditionValues {
+			if allowedValue == conditionValueString.ValueString() {
+				// Condition string value found, continue
+				conditionValueMatch = true
+				break
+			}
+		}
+		if conditionValueMatch {
+			break
+		}
+	}
+
+	if !conditionValueMatch {
+		return
+	}
+
+	// If we got here, the condition attribute was found with a condition value, so the implied attributes are required
+	for _, impliedAttr := range v.Implied {
+		impliedMatchedPaths, impliedDiags := req.Config.PathMatches(ctx, impliedAttr)
+
+		resp.Diagnostics.Append(impliedDiags...)
+		if impliedDiags.HasError() {
+			return
+		}
+
+		valueFound := false
+		for _, matchedPath := range impliedMatchedPaths {
+			getAttributeDiags := req.Config.GetAttribute(ctx, matchedPath, &impliedValue)
+
+			resp.Diagnostics.Append(getAttributeDiags...)
+			if getAttributeDiags.HasError() {
+				return
+			}
+
+			// If value is unknown, it may be null or a value, so we cannot
+			// know if the validator should succeed or not.
+			if impliedValue.IsUnknown() {
+				return
+			}
+
+			// If the value is null, then try the next one
+			if impliedValue.IsNull() {
+				continue
+			}
+
+			// Value is known and not null, it is configured, so this attribute passes
+			valueFound = true
+		}
+
+		// If we got here, then the condition value is configured and one of the implied values is not, so
+		// this validator should fail
+		if !valueFound {
+			resp.Diagnostics.Append(diag.NewErrorDiagnostic(
+				"Missing Implied Attribute Configuration",
+				v.Description(ctx),
+			))
+			return
+		}
+	}
+}

--- a/internal/operations/operation.go
+++ b/internal/operations/operation.go
@@ -139,7 +139,7 @@ func AddStringSetOperationsIfNecessary(ops *[]client.Operation, plan types.Set, 
 
 		// Adds
 		for _, planEl := range planElements {
-			if !internaltypes.Contains(stateElements, planEl.(types.String)) {
+			if !internaltypes.Contains(stateElements, planEl) {
 				op := client.NewOperation(client.ENUMOPERATION_ADD, path)
 				op.SetValue(planEl.(types.String).ValueString())
 				*ops = append(*ops, *op)
@@ -148,7 +148,7 @@ func AddStringSetOperationsIfNecessary(ops *[]client.Operation, plan types.Set, 
 
 		// Removes
 		for _, stateEl := range stateElements {
-			if !internaltypes.Contains(planElements, stateEl.(types.String)) {
+			if !internaltypes.Contains(planElements, stateEl) {
 				op := client.NewOperation(client.ENUMOPERATION_REMOVE, removeMultiValuedAttributePath(path, stateEl.(types.String).ValueString()))
 				*ops = append(*ops, *op)
 			}

--- a/internal/resource/config/accesstokenvalidator/access_token_validator_resource.go
+++ b/internal/resource/config/accesstokenvalidator/access_token_validator_resource.go
@@ -413,6 +413,16 @@ func configValidatorsAccessTokenValidator() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ping-federate",
+			[]path.Expression{path.MatchRoot("client_id")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("evaluation_order_index"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/accountstatusnotificationhandler/account_status_notification_handler_resource.go
+++ b/internal/resource/config/accountstatusnotificationhandler/account_status_notification_handler_resource.go
@@ -578,6 +578,31 @@ func configValidatorsAccountStatusNotificationHandler() []resource.ConfigValidat
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"smtp",
+			[]path.Expression{path.MatchRoot("sender_address"), path.MatchRoot("message_subject"), path.MatchRoot("message_template_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"admin-alert",
+			[]path.Expression{path.MatchRoot("account_status_notification_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"error-log",
+			[]path.Expression{path.MatchRoot("account_status_notification_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/alerthandler/alert_handler_resource.go
+++ b/internal/resource/config/alerthandler/alert_handler_resource.go
@@ -520,6 +520,51 @@ func configValidatorsAlertHandler() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"smtp",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("sender_address"), path.MatchRoot("recipient_address")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"jmx",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"snmp",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"twilio",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("twilio_account_sid"), path.MatchRoot("sender_phone_number"), path.MatchRoot("recipient_phone_number")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"error-log",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"snmp-sub-agent",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"exec",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("command")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/azureauthenticationmethod/azure_authentication_method_resource.go
+++ b/internal/resource/config/azureauthenticationmethod/azure_authentication_method_resource.go
@@ -184,6 +184,16 @@ func configValidatorsAzureAuthenticationMethod() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"username-password"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"client-secret",
+			[]path.Expression{path.MatchRoot("tenant_id"), path.MatchRoot("client_id"), path.MatchRoot("client_secret")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"username-password",
+			[]path.Expression{path.MatchRoot("tenant_id"), path.MatchRoot("client_id"), path.MatchRoot("username"), path.MatchRoot("password")},
+		),
 	}
 }
 

--- a/internal/resource/config/backend/backend_resource.go
+++ b/internal/resource/config/backend/backend_resource.go
@@ -1239,6 +1239,11 @@ func configValidatorsBackend() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"local-db"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"local-db",
+			[]path.Expression{path.MatchRoot("backend_id"), path.MatchRoot("base_dn"), path.MatchRoot("enabled")},
+		),
 	}
 }
 

--- a/internal/resource/config/certificatemapper/certificate_mapper_resource.go
+++ b/internal/resource/config/certificatemapper/certificate_mapper_resource.go
@@ -269,6 +269,26 @@ func configValidatorsCertificateMapper() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"subject-attribute-to-user-attribute",
+			[]path.Expression{path.MatchRoot("subject_attribute_mapping")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"fingerprint",
+			[]path.Expression{path.MatchRoot("fingerprint_algorithm")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/changesubscriptionhandler/change_subscription_handler_resource.go
+++ b/internal/resource/config/changesubscriptionhandler/change_subscription_handler_resource.go
@@ -224,6 +224,16 @@ func configValidatorsChangeSubscriptionHandler() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/cipherstreamprovider/cipher_stream_provider_resource.go
+++ b/internal/resource/config/cipherstreamprovider/cipher_stream_provider_resource.go
@@ -665,6 +665,46 @@ func configValidatorsCipherStreamProvider() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"amazon-secrets-manager",
+			[]path.Expression{path.MatchRoot("aws_external_server"), path.MatchRoot("secret_id"), path.MatchRoot("secret_field_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"amazon-key-management-service",
+			[]path.Expression{path.MatchRoot("kms_encryption_key_arn")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"azure-key-vault",
+			[]path.Expression{path.MatchRoot("key_vault_uri"), path.MatchRoot("azure_authentication_method"), path.MatchRoot("secret_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based",
+			[]path.Expression{path.MatchRoot("password_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"conjur",
+			[]path.Expression{path.MatchRoot("conjur_external_server"), path.MatchRoot("conjur_secret_relative_path")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"pkcs11",
+			[]path.Expression{path.MatchRoot("ssl_cert_nickname")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"vault",
+			[]path.Expression{path.MatchRoot("vault_secret_path"), path.MatchRoot("vault_secret_field_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/connectioncriteria/connection_criteria_resource.go
+++ b/internal/resource/config/connectioncriteria/connection_criteria_resource.go
@@ -603,6 +603,11 @@ func configValidatorsConnectionCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/connectionhandler/connection_handler_resource.go
+++ b/internal/resource/config/connectionhandler/connection_handler_resource.go
@@ -751,6 +751,21 @@ func configValidatorsConnectionHandler() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"http"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"jmx",
+			[]path.Expression{path.MatchRoot("listen_port")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ldap",
+			[]path.Expression{path.MatchRoot("listen_port")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"http",
+			[]path.Expression{path.MatchRoot("listen_port")},
+		),
 	}
 }
 

--- a/internal/resource/config/datasecurityauditor/data_security_auditor_resource.go
+++ b/internal/resource/config/datasecurityauditor/data_security_auditor_resource.go
@@ -407,6 +407,21 @@ func configValidatorsDataSecurityAuditor() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"filter",
+			[]path.Expression{path.MatchRoot("report_file"), path.MatchRoot("filter")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("report_file"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"idle-account",
+			[]path.Expression{path.MatchRoot("idle_account_warning_interval")},
+		),
 	}
 }
 

--- a/internal/resource/config/extendedoperationhandler/extended_operation_handler_resource.go
+++ b/internal/resource/config/extendedoperationhandler/extended_operation_handler_resource.go
@@ -409,6 +409,46 @@ func configValidatorsExtendedOperationHandler() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"validate-totp-password",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"replace-certificate",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"collect-support-data",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"export-reversible-passwords",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"single-use-tokens",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("password_generator"), path.MatchRoot("default_otp_delivery_mechanism")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"deliver-password-reset-token",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("password_generator"), path.MatchRoot("default_token_delivery_mechanism")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"deliver-otp",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("identity_mapper"), path.MatchRoot("password_generator"), path.MatchRoot("default_otp_delivery_mechanism")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/externalserver/external_server_resource.go
+++ b/internal/resource/config/externalserver/external_server_resource.go
@@ -827,6 +827,86 @@ func configValidatorsExternalServer() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"vault"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"smtp",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"nokia-ds",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ping-identity-ds",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"active-directory",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog",
+			[]path.Expression{path.MatchRoot("server_host_name"), path.MatchRoot("transport_mechanism")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ping-identity-proxy-server",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"http-proxy",
+			[]path.Expression{path.MatchRoot("server_host_name"), path.MatchRoot("server_port")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"nokia-proxy-server",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"opendj",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ldap",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"oracle-unified-directory",
+			[]path.Expression{path.MatchRoot("server_host_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"jdbc",
+			[]path.Expression{path.MatchRoot("jdbc_driver_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"http",
+			[]path.Expression{path.MatchRoot("base_url")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"conjur",
+			[]path.Expression{path.MatchRoot("conjur_server_base_uri"), path.MatchRoot("conjur_authentication_method"), path.MatchRoot("conjur_account_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"amazon-aws",
+			[]path.Expression{path.MatchRoot("aws_region_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"vault",
+			[]path.Expression{path.MatchRoot("vault_server_base_uri"), path.MatchRoot("vault_authentication_method")},
+		),
 	}
 }
 

--- a/internal/resource/config/failurelockoutaction/failure_lockout_action_resource.go
+++ b/internal/resource/config/failurelockoutaction/failure_lockout_action_resource.go
@@ -180,6 +180,11 @@ func configValidatorsFailureLockoutAction() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"delay-bind-response", "no-operation"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"delay-bind-response",
+			[]path.Expression{path.MatchRoot("delay")},
+		),
 	}
 }
 

--- a/internal/resource/config/httpservletextension/http_servlet_extension_resource.go
+++ b/internal/resource/config/httpservletextension/http_servlet_extension_resource.go
@@ -1029,6 +1029,26 @@ func configValidatorsHttpServletExtension() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"availability-state",
+			[]path.Expression{path.MatchRoot("base_context_path"), path.MatchRoot("available_status_code"), path.MatchRoot("degraded_status_code"), path.MatchRoot("unavailable_status_code")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-server",
+			[]path.Expression{path.MatchRoot("base_context_path"), path.MatchRoot("document_root_directory")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/identitymapper/identity_mapper_resource.go
+++ b/internal/resource/config/identitymapper/identity_mapper_resource.go
@@ -301,6 +301,21 @@ func configValidatorsIdentityMapper() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"regular-expression",
+			[]path.Expression{path.MatchRoot("match_pattern")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/idtokenvalidator/id_token_validator_resource.go
+++ b/internal/resource/config/idtokenvalidator/id_token_validator_resource.go
@@ -256,6 +256,11 @@ func configValidatorsIdTokenValidator() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"openid-connect"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"openid-connect",
+			[]path.Expression{path.MatchRoot("allowed_signing_algorithm")},
+		),
 	}
 }
 

--- a/internal/resource/config/keymanagerprovider/key_manager_provider_resource.go
+++ b/internal/resource/config/keymanagerprovider/key_manager_provider_resource.go
@@ -335,6 +335,21 @@ func configValidatorsKeyManagerProvider() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based",
+			[]path.Expression{path.MatchRoot("key_store_file"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"pkcs11",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/logfilerotationlistener/log_file_rotation_listener_resource.go
+++ b/internal/resource/config/logfilerotationlistener/log_file_rotation_listener_resource.go
@@ -210,6 +210,16 @@ func configValidatorsLogFileRotationListener() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"copy",
+			[]path.Expression{path.MatchRoot("copy_to_directory")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/logpublisher/log_publisher_resource.go
+++ b/internal/resource/config/logpublisher/log_publisher_resource.go
@@ -1691,6 +1691,186 @@ func configValidatorsLogPublisher() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"groovy-scripted-file-based-access", "groovy-scripted-file-based-error", "groovy-scripted-access", "groovy-scripted-error", "groovy-scripted-http-operation"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-json-audit",
+			[]path.Expression{path.MatchRoot("syslog_external_server"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-text-error",
+			[]path.Expression{path.MatchRoot("syslog_external_server"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-text-access",
+			[]path.Expression{path.MatchRoot("syslog_external_server"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-json-http-operation",
+			[]path.Expression{path.MatchRoot("syslog_external_server"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-json-access",
+			[]path.Expression{path.MatchRoot("syslog_external_server"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-json-error",
+			[]path.Expression{path.MatchRoot("syslog_external_server"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-based-error",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party-file-based-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"operation-timing-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party-http-operation",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"admin-alert-access",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-trace",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"jdbc-based-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("server"), path.MatchRoot("log_field_mapping")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"jdbc-based-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("server"), path.MatchRoot("log_field_mapping")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"common-log-file-http-operation",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"syslog-based-access",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-json-audit",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-debug",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"detailed-http-operation",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"json-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"debug-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-audit",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"json-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted-file-based-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted-file-based-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party-file-based-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"console-json-audit",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"console-json-http-operation",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-access",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted-error",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based-json-http-operation",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted-http-operation",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("script_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/logretentionpolicy/log_retention_policy_resource.go
+++ b/internal/resource/config/logretentionpolicy/log_retention_policy_resource.go
@@ -180,6 +180,26 @@ func configValidatorsLogRetentionPolicy() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"size-limit"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"time-limit",
+			[]path.Expression{path.MatchRoot("retain_duration")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-count",
+			[]path.Expression{path.MatchRoot("number_of_files")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"free-disk-space",
+			[]path.Expression{path.MatchRoot("free_disk_space")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"size-limit",
+			[]path.Expression{path.MatchRoot("disk_space_used")},
+		),
 	}
 }
 

--- a/internal/resource/config/logrotationpolicy/log_rotation_policy_resource.go
+++ b/internal/resource/config/logrotationpolicy/log_rotation_policy_resource.go
@@ -177,6 +177,21 @@ func configValidatorsLogRotationPolicy() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"size-limit"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"time-limit",
+			[]path.Expression{path.MatchRoot("rotation_interval")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"fixed-time",
+			[]path.Expression{path.MatchRoot("time_of_day")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"size-limit",
+			[]path.Expression{path.MatchRoot("file_size_limit")},
+		),
 	}
 }
 

--- a/internal/resource/config/monitorprovider/monitor_provider_resource.go
+++ b/internal/resource/config/monitorprovider/monitor_provider_resource.go
@@ -307,6 +307,16 @@ func configValidatorsMonitorProvider() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"encryption-settings-database-accessibility",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/oauthtokenhandler/oauth_token_handler_resource.go
+++ b/internal/resource/config/oauthtokenhandler/oauth_token_handler_resource.go
@@ -195,6 +195,16 @@ func configValidatorsOauthTokenHandler() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/otpdeliverymechanism/otp_delivery_mechanism_resource.go
+++ b/internal/resource/config/otpdeliverymechanism/otp_delivery_mechanism_resource.go
@@ -379,6 +379,21 @@ func configValidatorsOtpDeliveryMechanism() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"twilio",
+			[]path.Expression{path.MatchRoot("twilio_account_sid"), path.MatchRoot("sender_phone_number")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"email",
+			[]path.Expression{path.MatchRoot("sender_address")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/passphraseprovider/passphrase_provider_resource.go
+++ b/internal/resource/config/passphraseprovider/passphrase_provider_resource.go
@@ -412,6 +412,46 @@ func configValidatorsPassphraseProvider() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"environment-variable",
+			[]path.Expression{path.MatchRoot("environment_variable")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"amazon-secrets-manager",
+			[]path.Expression{path.MatchRoot("aws_external_server"), path.MatchRoot("secret_id"), path.MatchRoot("secret_field_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"obscured-value",
+			[]path.Expression{path.MatchRoot("obscured_value")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"azure-key-vault",
+			[]path.Expression{path.MatchRoot("key_vault_uri"), path.MatchRoot("azure_authentication_method"), path.MatchRoot("secret_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based",
+			[]path.Expression{path.MatchRoot("password_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"conjur",
+			[]path.Expression{path.MatchRoot("conjur_external_server"), path.MatchRoot("conjur_secret_relative_path")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"vault",
+			[]path.Expression{path.MatchRoot("vault_external_server"), path.MatchRoot("vault_secret_path"), path.MatchRoot("vault_secret_field_name")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/passthroughauthenticationhandler/pass_through_authentication_handler_resource.go
+++ b/internal/resource/config/passthroughauthenticationhandler/pass_through_authentication_handler_resource.go
@@ -532,6 +532,26 @@ func configValidatorsPassThroughAuthenticationHandler() []resource.ConfigValidat
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ping-one",
+			[]path.Expression{path.MatchRoot("api_url"), path.MatchRoot("auth_url"), path.MatchRoot("oauth_client_id"), path.MatchRoot("environment_id"), path.MatchRoot("user_mapping_local_attribute"), path.MatchRoot("user_mapping_remote_json_field")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ldap",
+			[]path.Expression{path.MatchRoot("server")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"aggregate",
+			[]path.Expression{path.MatchRoot("subordinate_pass_through_authentication_handler")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/passwordgenerator/password_generator_resource.go
+++ b/internal/resource/config/passwordgenerator/password_generator_resource.go
@@ -279,6 +279,26 @@ func configValidatorsPasswordGenerator() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"random",
+			[]path.Expression{path.MatchRoot("password_character_set"), path.MatchRoot("password_format")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"passphrase",
+			[]path.Expression{path.MatchRoot("dictionary_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/passwordstoragescheme/password_storage_scheme_resource.go
+++ b/internal/resource/config/passwordstoragescheme/password_storage_scheme_resource.go
@@ -475,6 +475,81 @@ func configValidatorsPasswordStorageScheme() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"scrypt"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"argon2d",
+			[]path.Expression{path.MatchRoot("salt_length_bytes"), path.MatchRoot("enabled"), path.MatchRoot("iteration_count"), path.MatchRoot("parallelism_factor"), path.MatchRoot("memory_usage_kb"), path.MatchRoot("derived_key_length_bytes")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"argon2i",
+			[]path.Expression{path.MatchRoot("salt_length_bytes"), path.MatchRoot("enabled"), path.MatchRoot("iteration_count"), path.MatchRoot("parallelism_factor"), path.MatchRoot("memory_usage_kb"), path.MatchRoot("derived_key_length_bytes")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"argon2id",
+			[]path.Expression{path.MatchRoot("salt_length_bytes"), path.MatchRoot("enabled"), path.MatchRoot("iteration_count"), path.MatchRoot("parallelism_factor"), path.MatchRoot("memory_usage_kb"), path.MatchRoot("derived_key_length_bytes")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"argon2",
+			[]path.Expression{path.MatchRoot("salt_length_bytes"), path.MatchRoot("enabled"), path.MatchRoot("iteration_count"), path.MatchRoot("parallelism_factor"), path.MatchRoot("memory_usage_kb"), path.MatchRoot("derived_key_length_bytes")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"crypt",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"vault",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("vault_external_server")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party-enhanced",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"pbkdf2",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"aes-256",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"bcrypt",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"amazon-secrets-manager",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("aws_external_server")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"azure-key-vault",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("key_vault_uri"), path.MatchRoot("azure_authentication_method")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"conjur",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("conjur_external_server")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"scrypt",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
 	}
 }
 

--- a/internal/resource/config/passwordvalidator/password_validator_resource.go
+++ b/internal/resource/config/passwordvalidator/password_validator_resource.go
@@ -761,6 +761,76 @@ func configValidatorsPasswordValidator() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"character-set",
+			[]path.Expression{path.MatchRoot("character_set"), path.MatchRoot("allow_unclassified_characters"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"similarity-based",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("min_password_difference")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"attribute-value",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("test_reversed_password")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"repeated-characters",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("max_consecutive_length"), path.MatchRoot("case_sensitive_validation")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"dictionary",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"haystack",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"utf-8",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"pwned-passwords",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"disallowed-characters",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"length-based",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"regular-expression",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("match_pattern"), path.MatchRoot("match_behavior")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"unique-characters",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("case_sensitive_validation"), path.MatchRoot("min_unique_characters")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/plugin/plugin_resource.go
+++ b/internal/resource/config/plugin/plugin_resource.go
@@ -1455,6 +1455,11 @@ func modifyPlanPlugin(ctx context.Context, req resource.ModifyPlanRequest, resp 
 // Add config validators that apply to both default_ and non-default_
 func configValidatorsPlugin() []resource.ConfigValidator {
 	return []resource.ConfigValidator{
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			[]string{"search-shutdown"},
+			[]path.Expression{path.MatchRoot("filter"), path.MatchRoot("output_file")},
+		),
 		configvalidators.ImpliesOtherValidator(
 			path.MatchRoot("type"),
 			[]string{"changelog-password-encryption"},

--- a/internal/resource/config/plugin/plugin_resource.go
+++ b/internal/resource/config/plugin/plugin_resource.go
@@ -1455,13 +1455,8 @@ func modifyPlanPlugin(ctx context.Context, req resource.ModifyPlanRequest, resp 
 // Add config validators that apply to both default_ and non-default_
 func configValidatorsPlugin() []resource.ConfigValidator {
 	return []resource.ConfigValidator{
-		configvalidators.ValueImpliesAttributeRequired(
-			path.MatchRoot("resource_type"),
-			[]string{"search-shutdown"},
-			[]path.Expression{path.MatchRoot("filter"), path.MatchRoot("output_file")},
-		),
 		configvalidators.ImpliesOtherValidator(
-			path.MatchRoot("type"),
+			path.MatchRoot("resource_type"),
 			[]string{"changelog-password-encryption"},
 			resourcevalidator.ExactlyOneOf(
 				path.MatchRoot("changelog_password_encryption_key"),
@@ -1469,7 +1464,7 @@ func configValidatorsPlugin() []resource.ConfigValidator {
 			),
 		),
 		configvalidators.ImpliesOtherValidator(
-			path.MatchRoot("type"),
+			path.MatchRoot("resource_type"),
 			[]string{"pass-through-authentication"},
 			resourcevalidator.Conflicting(
 				path.MatchRoot("dn_map"),
@@ -1477,7 +1472,7 @@ func configValidatorsPlugin() []resource.ConfigValidator {
 			),
 		),
 		configvalidators.ImpliesOtherValidator(
-			path.MatchRoot("type"),
+			path.MatchRoot("resource_type"),
 			[]string{"ping-one-pass-through-authentication"},
 			resourcevalidator.ExactlyOneOf(
 				path.MatchRoot("oauth_client_secret"),
@@ -1485,7 +1480,7 @@ func configValidatorsPlugin() []resource.ConfigValidator {
 			),
 		),
 		configvalidators.ImpliesOtherValidator(
-			path.MatchRoot("type"),
+			path.MatchRoot("resource_type"),
 			[]string{"pass-through-authentication"},
 			resourcevalidator.Conflicting(
 				path.MatchRoot("bind_dn_pattern"),
@@ -1493,7 +1488,7 @@ func configValidatorsPlugin() []resource.ConfigValidator {
 			),
 		),
 		configvalidators.ImpliesOtherValidator(
-			path.MatchRoot("type"),
+			path.MatchRoot("resource_type"),
 			[]string{"pass-through-authentication"},
 			resourcevalidator.Conflicting(
 				path.MatchRoot("dn_map"),
@@ -1501,7 +1496,7 @@ func configValidatorsPlugin() []resource.ConfigValidator {
 			),
 		),
 		configvalidators.ImpliesOtherValidator(
-			path.MatchRoot("type"),
+			path.MatchRoot("resource_type"),
 			[]string{"clean-up-expired-pingfederate-persistent-access-grants", "purge-expired-data", "clean-up-inactive-pingfederate-persistent-sessions", "clean-up-expired-pingfederate-persistent-sessions"},
 			configvalidators.Implies(
 				path.MatchRoot("datetime_json_field"),
@@ -2132,6 +2127,136 @@ func configValidatorsPlugin() []resource.ConfigValidator {
 			path.MatchRoot("prevent_conflicts_with_soft_deleted_entries"),
 			path.MatchRoot("resource_type"),
 			[]string{"unique-attribute"},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"coalesce-modifications",
+			[]path.Expression{path.MatchRoot("request_criteria"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"internal-search-rate",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("base_dn"), path.MatchRoot("filter_prefix")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"modifiable-password-policy-state",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"seven-bit-clean",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"clean-up-expired-pingfederate-persistent-access-grants",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"periodic-gc",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("invoke_gc_time_utc")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"ping-one-pass-through-authentication",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("api_url"), path.MatchRoot("auth_url"), path.MatchRoot("oauth_client_id"), path.MatchRoot("environment_id"), path.MatchRoot("user_mapping_local_attribute"), path.MatchRoot("user_mapping_remote_json_field")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"search-shutdown",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("filter"), path.MatchRoot("scope"), path.MatchRoot("output_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"periodic-stats-logger",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("log_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"purge-expired-data",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("datetime_attribute"), path.MatchRoot("expiration_offset")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"sub-operation-timing",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("plugin_type"), path.MatchRoot("extension_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"pass-through-authentication",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("server")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"dn-mapper",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("source_dn"), path.MatchRoot("target_dn")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"referral-on-update",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("referral_base_url")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"simple-to-external-bind",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"snmp-subagent",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"clean-up-inactive-pingfederate-persistent-sessions",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("expiration_offset")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"composed-attribute",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("value_pattern")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"attribute-mapper",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("source_attribute"), path.MatchRoot("target_attribute")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"delay",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("delay")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"clean-up-expired-pingfederate-persistent-sessions",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("plugin_type"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"pluggable-pass-through-authentication",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("pass_through_authentication_handler")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"referential-integrity",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("resource_type"),
+			"unique-attribute",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("type")},
 		),
 	}
 }

--- a/internal/resource/config/recurringtask/recurring_task_resource.go
+++ b/internal/resource/config/recurringtask/recurring_task_resource.go
@@ -1117,6 +1117,36 @@ func configValidatorsRecurringTask() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"generate-server-profile",
+			[]path.Expression{path.MatchRoot("profile_directory")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"statically-defined",
+			[]path.Expression{path.MatchRoot("task_java_class"), path.MatchRoot("task_object_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"collect-support-data",
+			[]path.Expression{path.MatchRoot("output_directory")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"exec",
+			[]path.Expression{path.MatchRoot("command_path")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-retention",
+			[]path.Expression{path.MatchRoot("target_directory"), path.MatchRoot("filename_pattern"), path.MatchRoot("timestamp_format")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/requestcriteria/request_criteria_resource.go
+++ b/internal/resource/config/requestcriteria/request_criteria_resource.go
@@ -654,6 +654,11 @@ func configValidatorsRequestCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/resultcriteria/result_criteria_resource.go
+++ b/internal/resource/config/resultcriteria/result_criteria_resource.go
@@ -880,6 +880,11 @@ func configValidatorsResultCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/saslmechanismhandler/sasl_mechanism_handler_resource.go
+++ b/internal/resource/config/saslmechanismhandler/sasl_mechanism_handler_resource.go
@@ -475,6 +475,26 @@ func configValidatorsSaslMechanismHandler() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"unboundid-ms-chap-v2",
+			[]path.Expression{path.MatchRoot("identity_mapper"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"unboundid-delivered-otp",
+			[]path.Expression{path.MatchRoot("identity_mapper"), path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"oauth-bearer",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/scimresourcetype/scim_resource_type_resource.go
+++ b/internal/resource/config/scimresourcetype/scim_resource_type_resource.go
@@ -262,6 +262,11 @@ func configValidatorsScimResourceType() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"ldap-mapping"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"ldap-mapping",
+			[]path.Expression{path.MatchRoot("core_schema")},
+		),
 	}
 }
 

--- a/internal/resource/config/searchentrycriteria/search_entry_criteria_resource.go
+++ b/internal/resource/config/searchentrycriteria/search_entry_criteria_resource.go
@@ -450,6 +450,11 @@ func configValidatorsSearchEntryCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/searchreferencecriteria/search_reference_criteria_resource.go
+++ b/internal/resource/config/searchreferencecriteria/search_reference_criteria_resource.go
@@ -300,6 +300,11 @@ func configValidatorsSearchReferenceCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/tokenclaimvalidation/token_claim_validation_resource.go
+++ b/internal/resource/config/tokenclaimvalidation/token_claim_validation_resource.go
@@ -205,6 +205,16 @@ func configValidatorsTokenClaimValidation() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"boolean"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"string",
+			[]path.Expression{path.MatchRoot("any_required_value")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"boolean",
+			[]path.Expression{path.MatchRoot("required_value")},
+		),
 	}
 }
 

--- a/internal/resource/config/trustmanagerprovider/trust_manager_provider_resource.go
+++ b/internal/resource/config/trustmanagerprovider/trust_manager_provider_resource.go
@@ -236,6 +236,16 @@ func configValidatorsTrustManagerProvider() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"file-based",
+			[]path.Expression{path.MatchRoot("trust_store_file")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/uncachedattributecriteria/uncached_attribute_criteria_resource.go
+++ b/internal/resource/config/uncachedattributecriteria/uncached_attribute_criteria_resource.go
@@ -244,6 +244,21 @@ func configValidatorsUncachedAttributeCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"simple",
+			[]path.Expression{path.MatchRoot("attribute_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/uncachedentrycriteria/uncached_entry_criteria_resource.go
+++ b/internal/resource/config/uncachedentrycriteria/uncached_entry_criteria_resource.go
@@ -235,6 +235,26 @@ func configValidatorsUncachedEntryCriteria() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"last-access-time",
+			[]path.Expression{path.MatchRoot("access_time_threshold")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"filter-based",
+			[]path.Expression{path.MatchRoot("filter")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/vaultauthenticationmethod/vault_authentication_method_resource.go
+++ b/internal/resource/config/vaultauthenticationmethod/vault_authentication_method_resource.go
@@ -208,6 +208,21 @@ func configValidatorsVaultAuthenticationMethod() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"user-pass"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"static-token",
+			[]path.Expression{path.MatchRoot("vault_access_token")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"app-role",
+			[]path.Expression{path.MatchRoot("vault_role_id"), path.MatchRoot("vault_secret_id")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"user-pass",
+			[]path.Expression{path.MatchRoot("username"), path.MatchRoot("password")},
+		),
 	}
 }
 

--- a/internal/resource/config/velocitycontextprovider/velocity_context_provider_resource.go
+++ b/internal/resource/config/velocitycontextprovider/velocity_context_provider_resource.go
@@ -287,6 +287,11 @@ func configValidatorsVelocityContextProvider() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/virtualattribute/virtual_attribute_resource.go
+++ b/internal/resource/config/virtualattribute/virtual_attribute_resource.go
@@ -701,6 +701,71 @@ func configValidatorsVirtualAttribute() []resource.ConfigValidator {
 			path.MatchRoot("type"),
 			[]string{"third-party"},
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"mirror",
+			[]path.Expression{path.MatchRoot("source_attribute"), path.MatchRoot("enabled"), path.MatchRoot("attribute_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"constructed",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("value_pattern")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"is-member-of",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"reverse-dn-join",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("join_dn_attribute"), path.MatchRoot("join_base_dn_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"identify-references",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("referenced_by_attribute")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"user-defined",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("value")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"entry-dn",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"equality-join",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("join_base_dn_type"), path.MatchRoot("join_source_attribute"), path.MatchRoot("join_target_attribute")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"groovy-scripted",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("script_class")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"member",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"password-policy-state-json",
+			[]path.Expression{path.MatchRoot("enabled")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"dn-join",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("join_dn_attribute"), path.MatchRoot("join_base_dn_type")},
+		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"third-party",
+			[]path.Expression{path.MatchRoot("enabled"), path.MatchRoot("attribute_type"), path.MatchRoot("extension_class")},
+		),
 	}
 }
 

--- a/internal/resource/config/webapplicationextension/web_application_extension_resource.go
+++ b/internal/resource/config/webapplicationextension/web_application_extension_resource.go
@@ -273,6 +273,11 @@ func configValidatorsWebApplicationExtension() []resource.ConfigValidator {
 				path.MatchRoot("oidc_client_secret_passphrase_provider"),
 			),
 		),
+		configvalidators.ValueImpliesAttributeRequired(
+			path.MatchRoot("type"),
+			"generic",
+			[]path.Expression{path.MatchRoot("base_context_path")},
+		),
 	}
 }
 


### PR DESCRIPTION
Add configvalidators to mark attributes as required when they are only required for a subset of types for a resource